### PR TITLE
Add contributor onboarding, seed pilot assets, and quick-start simulations

### DIFF
--- a/.github/ISSUE_TEMPLATE/experiment_report.md
+++ b/.github/ISSUE_TEMPLATE/experiment_report.md
@@ -1,0 +1,20 @@
+---
+name: "Experiment report"
+about: Log results from a run
+labels: experiment
+---
+
+## Summary
+What you tested and why.
+
+## Setup
+- Location:
+- Module IDs:
+- Conditions: (solar W/m², temp °C, RH %, wind m/s)
+- Feed water (TDS mg/L)
+
+## Results (attach CSV)
+Key metrics (flux, daily L, kWh/L, TDS out, availability)
+
+## Notes
+Lessons, issues, follow-ups

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: "Feature request"
+about: Suggest an idea or improvement
+labels: enhancement
+---
+
+## What & Why
+Describe the feature and the problem it solves.
+
+## Files/Paths
+List related files (paths) and links.
+
+## Acceptance Criteria
+- [ ] Clear benefit
+- [ ] Backward compatible
+- [ ] Linked docs/tests updated

--- a/03-deployment-framework/pilots/pilot_phase1_arizona.md
+++ b/03-deployment-framework/pilots/pilot_phase1_arizona.md
@@ -1,0 +1,31 @@
+# Pilot Phase 1 — Arizona (Draft)
+
+## Objective
+Demonstrate a small TriSource + MSSC + SPMD array suitable for an arid U.S. agricultural setting.
+
+## Targets
+- **Water**: 100 L/day (aggregate), distillate + polished water
+- **Energy (aux)**: < 7 kWh/day
+- **Soil**: Halophyte zone established; track soil EC and OM%
+
+## Layout (indicative)
+- SPMD collector area: 7–8 m² (assuming 1.4–1.7 L·m⁻²·h⁻¹ field, ~5–6 sun hours)
+- MSSC: pond → bog → irrigation trench; brine routed to halophytes
+- QA/Post-treatment: EC/T, UV or chlorine, remineralization; 3–5 days storage
+
+## Metrics & Logging
+- Flux, daily L, kWh/L, GOR (if multi-stage used), TDS reduction, availability
+- Soil EC (dS/m), soil OM (%), halophyte biomass
+- Use: `05-technical-resources/experiments/data/log_template.csv`
+
+## Steps & Timeline (draft)
+1. Site selection + stakeholder alignment (2–4 weeks)
+2. PoC module assembly + bench validation (4–6 weeks)
+3. On-site install + training (1–2 weeks)
+4. 60–90 day monitoring (data to repo)
+5. Review + iterate; plan Phase 2 scaling
+
+## Partners & Needs
+- Local farm or ag co-op
+- University lab for QC (water/soil)
+- NGO/ESG sponsor for deployment

--- a/05-technical-resources/boms/trisource_poc_bom.csv
+++ b/05-technical-resources/boms/trisource_poc_bom.csv
@@ -1,0 +1,12 @@
+component,description,qty,unit_cost_usd,source,notes
+frame_panels,HDPE or PVC sheets (6-10mm),4,25,local hardware,cut to fit PoC tray
+wick_pad,cellulose/cotton felt (~5-8mm),1,18,McMaster-Carr or local,textured for capillary flow
+photothermal_coat,carbon black pigment + binder,1,12,art supply/lab,spray/roll application
+clear_cover,polycarbonate sheet (UV stabilized),1,28,local hardware,10-12° slope
+gutter_troughs,aluminum or PVC channels,2,8,local hardware,edge-salt collection
+peristaltic_pump,12-24V DC low-flow,1,35,amazon/adafruit,feed control
+sensors,EC + temp probe,1,30,atlas scientific (or equiv),QA logging
+uv_unit,low-power UV sterilizer,1,40,aquarium supply,post-treatment
+tubing_fittings,3/8-1/2 inch quick-connects,1,15,local hardware,barbed or JG
+fasteners,stainless screws/bolts,1,10,local hardware,corrosion-resistant
+sealant,marine-grade silicone,1,9,local hardware,edge sealing

--- a/05-technical-resources/experiments/data/log_template.csv
+++ b/05-technical-resources/experiments/data/log_template.csv
@@ -1,0 +1,1 @@
+timestamp_iso,module_id,location,metric,value,units,method,notes

--- a/05-technical-resources/simulations/mssc_growth.py
+++ b/05-technical-resources/simulations/mssc_growth.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+MSSC toy model: logistic growth with simple temperature factor.
+This is a placeholder for contributors to extend (substrate, pH, multi-species).
+"""
+from pathlib import Path
+import csv, math
+
+OUT = Path(__file__).parent / "outputs"
+OUT.mkdir(parents=True, exist_ok=True)
+outfile = OUT / "mssc_growth_example.csv"
+
+# Parameters (tweak/PR with literature-backed defaults)
+r_max = 0.8      # 1/day, intrinsic growth
+K = 1.0          # normalized carrying capacity (0..1)
+T_opt = 30.0     # degC
+sigma = 7.0      # degC width
+dt = 0.1         # days
+days = 20
+
+def f_T(T):  # Gaussian temperature response [0..1]
+    return math.exp(-((T - T_opt) ** 2) / (2 * sigma ** 2))
+
+def step(x, r_eff, dt):
+    return x + r_eff * x * (1 - x / K) * dt
+
+rows = [("day","temp_c","biomass_norm")]
+for T in (20.0, 30.0):
+    x = 0.02
+    t = 0.0
+    while t <= days:
+        r_eff = r_max * f_T(T)
+        x = min(step(x, r_eff, dt), K)
+        rows.append((round(t,2), T, round(x,4)))
+        t += dt
+
+with outfile.open("w", newline="") as f:
+    csv.writer(f).writerows(rows)
+
+print(f"Wrote {outfile}")

--- a/05-technical-resources/simulations/spmd_sizing.py
+++ b/05-technical-resources/simulations/spmd_sizing.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+SPMD area sizing: daily liters vs lab flux, field derate, sun hours.
+"""
+from pathlib import Path
+import csv
+
+OUT = Path(__file__).parent / "outputs"
+OUT.mkdir(parents=True, exist_ok=True)
+outfile = OUT / "spmd_sizing_example.csv"
+
+lab_flux = 3.4            # L/m2/h (UNIST lab headline)
+derates = [0.4, 0.5]      # field fraction of lab
+sun_hours = [5, 6]        # effective hours/day
+targets = [60, 65]        # L/day
+
+rows = [("derate","sun_h","target_Ld","required_area_m2","field_flux_L_m2_h","daily_L_m2")]
+for d in derates:
+    field_flux = round(lab_flux * d, 2)
+    for sh in sun_hours:
+        daily = round(field_flux * sh, 2)
+        for tgt in targets:
+            area = round(tgt / daily, 2)
+            rows.append((d, sh, tgt, area, field_flux, daily))
+
+with outfile.open("w", newline="") as f:
+    csv.writer(f).writerows(rows)
+
+print("derate sunH targetLd -> area(m2) fieldFlux dailyLm2")
+for r in rows[1:]:
+    print(f"{r[0]:.1f}    {r[1]}    {r[2]} -> {r[3]} m2  {r[4]}  {r[5]}")
+print(f"Wrote {outfile}")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,33 @@
 # Contributing to eMSSC²
 
-Thank you for helping build open, regenerative water–energy–soil systems. Follow the guidelines below to ensure contributions are reviewable and reproducible.
+Thanks for helping build **zero-electric, regenerative water–energy–soil systems**.
 
-## Contribution Flow
-1. **Discuss**: Open an issue to describe the improvement, bug, or research task. Link to any relevant folders (e.g., `docs/05-technical-resources/experiments/Risk_Mitigated_Design_Sept2025.md`).
-2. **Design**: Outline your approach, data requirements, and dependencies. When logging experiments, use or extend the [data log template](05-technical-resources/experiments/data/log_template.csv) so field teams can replay the work.
-3. **Implement**: Create a branch and add your updates with clear commit messages. Document assumptions, calculations, and references directly in the files you modify.
-4. **Review**: Submit a pull request referencing the issue. Summarize changes, validation steps, and any follow-on tasks for the roadmap.
-5. **Merge & Log**: After approval, merge the PR and update related status docs or experiment logs to keep downstream collaborators informed.
+## Quick Start
+1. **Fork & Branch**: Fork → create a feature branch.
+2. **Pick a Lane**:
+   - **Simulations**: Add/extend models in `05-technical-resources/simulations/`.
+   - **Schematics**: Add SVGs to `05-technical-resources/figures/`.
+   - **Hardware/BOMs**: Contribute parts lists to `05-technical-resources/boms/`.
+   - **Pilots**: Propose/shape pilots in `03-deployment-framework/`.
+3. **Data**: Use `05-technical-resources/experiments/data/log_template.csv` for experiment logs.
+4. **PRs**: Open a pull request with context (what/why), and include screenshots or sample outputs where relevant.
 
-## Documentation Expectations
-- Provide context and intent for every change so reviewers understand the scenario.
-- Include calculations, parameter tables, or simulation configs used to generate results.
-- Attach figures, schematics, or data files in the appropriate subdirectories to maintain traceability.
+## Style & Conventions
+- **Code**: Python ≥3.10, PEP8, type hints encouraged.
+- **CSV**: UTF-8, ISO-8601 timestamps (`timestamp_iso`), snake_case headers.
+- **Figures**: Prefer SVG (vector). One accent color `#0B84F3` and orange `#FF7F0E` for brine.
+- **Docs**: Clear headings, short sections, link related files/paths.
 
 ## How to Brief AI Collaborators
+We use AI (Claude, DeepSeek, Grok, Kai, ChatGPT) as **on-demand reviewers**. They have no cross-session memory, so include:
+1. File path(s) you’re editing.
+2. Task goal and constraints (audience, license, deadline).
+3. Links to related docs (e.g., KPIs, schematics, status update).
 
-We use AI systems (e.g., Claude, Grok, DeepSeek, Kai) as **on-demand reviewers** for research synthesis, doc clarity, and technical cross-checks. They do not retain memory between sessions.
+**Template prompt:**
+> Review `02-integrated-systems/TriSource/INTERFACES.md` for clarity and alignment with `05-technical-resources/metrics/KPIs.md` and schematic `05-technical-resources/figures/trisource_node_simple.svg`. Suggest concise edits in Markdown.
 
-**When asking an AI for help, include:**
-1. The exact file or path you’re working on (e.g., `05-technical-resources/experiments/Risk_Mitigated_Design_Sept2025.md`).
-2. A short summary of the task (what needs review or drafting).
-3. Any key constraints (e.g., license, audience, deadlines).
-4. Links to related docs (status update, KPIs, schematics).
-
-**Example prompt snippet:**
-> “Please review `02-integrated-systems/TriSource/INTERFACES.md` for clarity and completeness. Ensure it aligns with `05-technical-resources/metrics/KPIs.md` and references the schematic `05-technical-resources/figures/trisource_node_simple.svg`. Output concise edits in Markdown.”
-
-Treat AI output as assistance to human contributors; verify before merging.
+## Community
+- **Issues**: Use GitHub Issues for bugs/ideas.
+- **Discussions** *(enable in Settings)*: “Announcements”, “Q&A”, “Experiments”, “Pilots”.
+- **Code of Conduct**: See `CODE_OF_CONDUCT.md`.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ Read our full statement here: [OPEN_SOURCE_DECLARATION.md](OPEN_SOURCE_DECLARATI
 
 ## 🤝 How to Engage
 
-- **Contribute**: Engineers, scientists, and practitioners are welcome to add to experiments, simulations, or deployment docs through pull requests.  
-- **Partner**: Institutions and companies (e.g., UNIST, NGOs, ag co-ops) can collaborate on pilots, field validation, and technology integration.  
-- **Fund**: Supporters and ESG investors can help accelerate prototypes, pilot sites, and agricultural resilience deployments.  
+- **Contribute**: Engineers, scientists, and practitioners are welcome to add to experiments, simulations, or deployment docs through pull requests.
+- **Partner**: Institutions and companies (e.g., UNIST, NGOs, ag co-ops) can collaborate on pilots, field validation, and technology integration.
+- **Fund**: Supporters and ESG investors can help accelerate prototypes, pilot sites, and agricultural resilience deployments.
 - **Follow**: Track progress through our [Status Updates](03-deployment-framework/README_Status_Sept2025.md) and upcoming GitHub Pages site.
+
+## ⚡ Quick Start
+- Run a sizing sim: `python 05-technical-resources/simulations/spmd_sizing.py`
+- Try the MSSC toy model: `python 05-technical-resources/simulations/mssc_growth.py`
+- Add a part to the BOM: edit `05-technical-resources/boms/trisource_poc_bom.csv`
+- Propose a pilot: edit `03-deployment-framework/pilots/pilot_phase1_arizona.md` and open a PR


### PR DESCRIPTION
## Summary
- refresh CONTRIBUTING.md with a quick-start lane guide, style rules, and AI briefing template
- add a Quick Start section in README that links to runnable simulations, BOM editing, and pilot docs
- seed runnable MSSC growth and SPMD sizing scripts plus a pilot BOM, Phase 1 Arizona outline, and issue templates to guide contributions

## Testing
- `python3 05-technical-resources/simulations/mssc_growth.py`
- `python3 05-technical-resources/simulations/spmd_sizing.py`


------
https://chatgpt.com/codex/tasks/task_e_68d55ef38e3c832c8529f814eb2c1db7