### PR TITLE
Add onboarding docs and seed technical resources

### DIFF
--- a/03-deployment-framework/pilots/pilot_phase1_nevada.md
+++ b/03-deployment-framework/pilots/pilot_phase1_nevada.md
@@ -1,0 +1,30 @@
+# Pilot Phase 1 — Nevada (Draft)
+
+## Objective
+Demonstrate a small TriSource + MSSC + SPMD array for an arid U.S. agricultural site.
+
+## Targets
+- Water: 100 L/day  
+- Energy (aux): <7 kWh/day  
+- Soil: Halophyte test bed, track EC and OM%  
+
+## Layout
+- SPMD collector area: 7–8 m² (derated field performance)  
+- MSSC: pond → bog → irrigation trench  
+- QA: EC/T sensors, UV unit, remineralization  
+
+## Metrics
+- Flux, daily liters, kWh/L, TDS reduction  
+- Soil EC (dS/m), OM (%)  
+- Log data via `05-technical-resources/experiments/data/log_template.csv`  
+
+## Timeline
+1. Site selection & partner alignment (2–4 weeks)  
+2. PoC module assembly (4–6 weeks)  
+3. Install & train (1–2 weeks)  
+4. Monitor 60–90 days, push logs to repo  
+
+## Partners
+- Local farm or ag co-op  
+- University QC lab (water/soil)  
+- NGO/ESG sponsor for deployment  

--- a/05-technical-resources/boms/trisource_poc_bom.csv
+++ b/05-technical-resources/boms/trisource_poc_bom.csv
@@ -1,12 +1,10 @@
-component,description,qty,unit_cost_usd,source,notes
-frame_panels,HDPE or PVC sheets (6-10mm),4,25,local hardware,cut to fit PoC tray
-wick_pad,cellulose/cotton felt (~5-8mm),1,18,McMaster-Carr or local,textured for capillary flow
-photothermal_coat,carbon black pigment + binder,1,12,art supply/lab,spray/roll application
-clear_cover,polycarbonate sheet (UV stabilized),1,28,local hardware,10-12° slope
-gutter_troughs,aluminum or PVC channels,2,8,local hardware,edge-salt collection
-peristaltic_pump,12-24V DC low-flow,1,35,amazon/adafruit,feed control
-sensors,EC + temp probe,1,30,atlas scientific (or equiv),QA logging
+component,description,quantity,unit_cost_usd,source,notes
+bioreactor_tank,10L HDPE vessel,1,50,local supplier,water-tight
+electrodes,graphite-based,2,25,lab supply,for electron transfer
+solar_module,10W LSMO panel,1,100,UNIST partner,photothermal desal
+piping,PVC connectors (3/8"),5m,10,hardware store,feed + brine
+gutter_troughs,aluminum channels,2,8,hardware store,edge-salt collection
+peristaltic_pump,12–24V DC low-flow,1,35,amazon/adafruit,feed control
+sensor_pack,EC + temp probes,1,30,atlas scientific,QA logging
 uv_unit,low-power UV sterilizer,1,40,aquarium supply,post-treatment
-tubing_fittings,3/8-1/2 inch quick-connects,1,15,local hardware,barbed or JG
-fasteners,stainless screws/bolts,1,10,local hardware,corrosion-resistant
-sealant,marine-grade silicone,1,9,local hardware,edge sealing
+sealant,marine-grade silicone,1,9,hardware store,edge sealing

--- a/05-technical-resources/figures/system_diagram.md
+++ b/05-technical-resources/figures/system_diagram.md
@@ -1,0 +1,12 @@
+# eMSSC² System Diagram (Mermaid)
+
+```mermaid
+graph TD
+    A[MSSC Bioreactor: Microbial Waste → Energy + Soil] --> B[TriSource Node: Resource Distribution]
+    B --> C[LSMO Desal: Solar-Powered Water]
+    C --> D[Outputs: Clean Water, Fertile Soil, Energy]
+```
+
+Figure: Simplified flow of MSSC → TriSource → UNIST SPMD → Outputs.
+
+---

--- a/05-technical-resources/simulations/mssc_growth_model.py
+++ b/05-technical-resources/simulations/mssc_growth_model.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+MSSC Bioreactor Growth Model (toy version).
+Contributors: extend with substrate depletion, pH/temp effects, or multiple strains.
+"""
+import math
+
+# Parameters (e.g., Geobacter or Shewanella strains)
+initial_biomass = 0.1  # g/L
+growth_rate = 0.05     # per hour
+max_capacity = 10.0    # g/L
+time_hours = 72
+
+def microbial_growth(t, biomass, rate, capacity):
+    """Logistic growth model"""
+    return biomass * math.exp(rate * t) / (1 - (biomass/capacity) * (1 - math.exp(rate * t)))
+
+print("Time (h), Biomass (g/L)")
+for t in range(0, time_hours + 1, 12):
+    biomass = microbial_growth(t, initial_biomass, growth_rate, max_capacity)
+    print(f"{t}, {biomass:.2f}")
+
+energy = biomass * 0.12  # 0.12 Wh/g (approx conversion)
+print(f"Estimated energy at {time_hours}h: {energy:.2f} Wh")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,36 @@
 # Contributing to eMSSC²
 
-Thanks for helping build **zero-electric, regenerative water–energy–soil systems**.
+Welcome to the **Exponential Microbial Systems for Sustainable Communities (eMSSC²)** project!  
+We’re building **zero-electric, regenerative water–energy–soil systems**.  
 
-## Quick Start
-1. **Fork & Branch**: Fork → create a feature branch.
-2. **Pick a Lane**:
-   - **Simulations**: Add/extend models in `05-technical-resources/simulations/`.
-   - **Schematics**: Add SVGs to `05-technical-resources/figures/`.
-   - **Hardware/BOMs**: Contribute parts lists to `05-technical-resources/boms/`.
-   - **Pilots**: Propose/shape pilots in `03-deployment-framework/`.
-3. **Data**: Use `05-technical-resources/experiments/data/log_template.csv` for experiment logs.
-4. **PRs**: Open a pull request with context (what/why), and include screenshots or sample outputs where relevant.
+## 🚀 How to Contribute
+1. **Fork & Clone**: Fork the repo and create a branch.  
+2. **Choose a Task**:
+   - **Simulations** → add models to `05-technical-resources/simulations/`.  
+   - **Hardware** → propose TriSource designs in `02-integrated-systems/`.  
+   - **Pilots** → suggest sites or plans in `03-deployment-framework/`.  
+3. **Submit a PR**: Use clear commit messages and link related files.  
+4. **Join Discussions**: Post questions, ideas, or feedback in GitHub Discussions.  
 
-## Style & Conventions
-- **Code**: Python ≥3.10, PEP8, type hints encouraged.
-- **CSV**: UTF-8, ISO-8601 timestamps (`timestamp_iso`), snake_case headers.
-- **Figures**: Prefer SVG (vector). One accent color `#0B84F3` and orange `#FF7F0E` for brine.
-- **Docs**: Clear headings, short sections, link related files/paths.
+## 🧩 Style & Conventions
+- **Code**: Python ≥3.10, PEP8.  
+- **CSV**: UTF-8, snake_case headers, ISO-8601 timestamps.  
+- **Figures**: Prefer SVG with one accent color (#0B84F3) and orange (#FF7F0E for brine).  
+- **Docs**: Keep short, reference file paths, and link related resources.  
 
-## How to Brief AI Collaborators
-We use AI (Claude, DeepSeek, Grok, Kai, ChatGPT) as **on-demand reviewers**. They have no cross-session memory, so include:
-1. File path(s) you’re editing.
-2. Task goal and constraints (audience, license, deadline).
-3. Links to related docs (e.g., KPIs, schematics, status update).
+## 🤖 AI Collaborators
+We use AI tools (Claude, DeepSeek, Grok, ChatGPT) as **on-demand reviewers**.  
+When asking for help, always include:  
+- File path(s)  
+- Task goal & constraints  
+- Related links  
 
-**Template prompt:**
-> Review `02-integrated-systems/TriSource/INTERFACES.md` for clarity and alignment with `05-technical-resources/metrics/KPIs.md` and schematic `05-technical-resources/figures/trisource_node_simple.svg`. Suggest concise edits in Markdown.
+**Example Prompt:**  
+> Review `02-integrated-systems/TriSource/INTERFACES.md` for clarity. Ensure it aligns with `05-technical-resources/metrics/KPIs.md` and schematic `05-technical-resources/figures/system_diagram.md`. Suggest concise edits.  
 
-## Community
-- **Issues**: Use GitHub Issues for bugs/ideas.
-- **Discussions** *(enable in Settings)*: “Announcements”, “Q&A”, “Experiments”, “Pilots”.
-- **Code of Conduct**: See `CODE_OF_CONDUCT.md`.
+## 🌍 Community
+- **Issues** → bugs, ideas, or feature requests  
+- **Discussions** → brainstorming, Q&A, experiments  
+- **Code of Conduct** → see `CODE_OF_CONDUCT.md`  
+
+Thank you for building regenerative infrastructure with us!

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 We orchestrate microbial electrochemical bioreactors, TriSource hybrid nodes, and photothermal desalination modules into a deployable platform for climate-stressed communities. The program aligns engineering, policy, and capital pathways so DOE/USAID reviewers, UNIST collaborators, and ESG funders can accelerate field-ready infrastructure that regenerates water, energy, and soil without grid dependencies.
 
+## 🚀 Join the eMSSC² Revolution
+- **Contribute**: Fork the repo, add simulations (`05-technical-resources/simulations/`), TriSource designs (`02-integrated-systems/`), or pilot plans (`03-deployment-framework/`).  
+- **Discuss**: Join GitHub Discussions (enabled soon) to share ideas and Q&A.  
+- **Spread the Word**: Star the repo and share with #eMSSC2 #OpenSource #Sustainability.  
+- **Explore**: See our [System Diagram](05-technical-resources/figures/system_diagram.md).  
+
 ![TriSource Node](05-technical-resources/figures/trisource_node_simple.svg)
 *Figure: TriSource integrates AWG, SPMD solar desal, and MSSC wetland polishing → QA → clean water storage.*
 


### PR DESCRIPTION
## Summary
- refresh CONTRIBUTING guidelines with onboarding steps and AI collaborator briefing
- add mermaid-based system diagram and highlight contribution pathways in the README
- seed simulation script, TriSource PoC BOM template, and Nevada pilot roadmap for new contributors

## Testing
- python 05-technical-resources/simulations/mssc_growth_model.py

------
https://chatgpt.com/codex/tasks/task_e_68d68eeb58f8832c98457732f4e47da3